### PR TITLE
Creadas funciones y estructuras para el checker de los objetos

### DIFF
--- a/render_bonus_files/get_color_at_hit_bonus.c
+++ b/render_bonus_files/get_color_at_hit_bonus.c
@@ -27,7 +27,8 @@ static int	is_in_shadow(t_hit hit, t_elem_light_p *light, t_list *objs)
 	return (shadow_hit.obj && shadow_hit.distance < vector_module(to_light));
 }
 
-static t_vector	get_light_contribution(t_hit hit, t_elem_light_p *light)
+static t_vector	get_light_contribution(t_hit hit, t_elem_light_p *light,
+	t_vector mat_color)
 {
 	t_vector	to_light;
 	double		n_dot_l;
@@ -40,11 +41,12 @@ static t_vector	get_light_contribution(t_hit hit, t_elem_light_p *light)
 		return (vector_new(0, 0, 0));
 	diffuse = light->ratio * n_dot_l;
 	return (color_hadamard(
-			color_hadamard(hit.obj->material.color, light->color),
+			color_hadamard(mat_color, light->color),
 			vector_new(diffuse, diffuse, diffuse)));
 }
 
-static t_vector	get_specular(t_hit hit, t_elem_light_p *light, t_rtapp *app)
+static t_vector	get_specular(t_hit hit, t_elem_light_p *light,
+	t_rtapp *app, t_vector mat_color)
 {
 	t_vector	to_light;
 	t_vector	view_dir;
@@ -67,14 +69,15 @@ static t_vector	get_specular(t_hit hit, t_elem_light_p *light, t_rtapp *app)
 	if (r_dot_v <= 0.0)
 		return (vector_new(0, 0, 0));
 	spec = light->ratio * pow(r_dot_v, hit.obj->material.shininess);
-	return (vector_mult_scalar(light->color, spec));
+	return (vector_mult_scalar(mat_color, spec));
 }
 
 static t_vector	get_puntual_lighting(
 	t_hit hit,
 	t_list *objs,
 	t_rtapp *app,
-	t_vector res
+	t_vector res,
+	t_vector mat_color
 )
 {
 	t_list			*light_node;
@@ -88,9 +91,9 @@ static t_vector	get_puntual_lighting(
 		light = (t_elem_light_p *)light_node->content;
 		if (!is_in_shadow(hit, light, objs))
 		{
-			tmp_color = get_light_contribution(hit, light);
+			tmp_color = get_light_contribution(hit, light, mat_color);
 			res = vector_sum_vector(res, tmp_color);
-			specular = get_specular(hit, light, app);
+			specular = get_specular(hit, light, app, mat_color);
 			res = vector_sum_vector(res, specular);
 		}
 		light_node = light_node->next;
@@ -106,12 +109,22 @@ t_vector	get_color_at_hit(
 {
 	t_vector	res;
 	t_vector	tmp_color;
+	t_vector	mat_color;
+	t_vector	local_point;
+	t_uv		uv;
 
 	res = vector_new(0, 0, 0);
-	tmp_color = hit.obj->material.color;
-	tmp_color = color_hadamard(tmp_color, app->ambient.color);
+	if (hit.obj->material.is_checker)
+	{
+		local_point = vector_mult_mat4_point(hit.pos, &hit.obj->transform.inv);
+		uv = hit.obj->c_uv_map(local_point);
+		mat_color = get_checker_color(uv);
+	}
+	else
+		mat_color = hit.obj->material.color;
+	tmp_color = color_hadamard(mat_color, app->ambient.color);
 	tmp_color = vector_mult_scalar(tmp_color, app->ambient.ratio);
 	res = vector_sum_vector(res, tmp_color);
-	res = get_puntual_lighting(hit, objs, app, res);
+	res = get_puntual_lighting(hit, objs, app, res, mat_color);
 	return (res);
 }

--- a/render_bonus_files/render_bonus.h
+++ b/render_bonus_files/render_bonus.h
@@ -6,7 +6,7 @@
 /*   By: aramos-r <aramos-r@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/25 17:19:44 by aramos-r          #+#    #+#             */
-/*   Updated: 2026/05/04 22:03:22 by aramos-r         ###   ########.fr       */
+/*   Updated: 2026/05/04 23:10:26 by aramos-r         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,24 @@ typedef struct s_material
 {
 	t_vector	color;
 	double		shininess;
+	int			is_checker;
 }	t_material;
+
+typedef struct s_uv
+{
+	double	u;
+	double	v;
+}	t_uv;
+
+typedef struct s_object
+{
+	t_transform	transform;
+	t_material	material;
+	void		*data;
+	double		(*c_intersection)(t_ray local_ray);
+	t_vector	(*c_normal)(t_vector point);
+	t_uv		(*c_uv_map)(t_vector local_point);
+}	t_object;
 
 /**
  * @brief Computes the color at a ray-object intersection point using the
@@ -173,5 +190,55 @@ t_vector	hb_normal(t_vector local_point);
  *       side surface is checked for intersections.
  */
 double		hb_intersection(t_ray local_ray);
+
+/**
+ * @brief Maps a sphere's local point to UV coordinates.
+ * @param local_point The point in the sphere's local object space.
+ * @return A T_UV with U = atan2(z,x)/(2π) + 0.5 and V = asin(y)/π + 0.5.
+ */
+t_uv		sphere_uv(t_vector local_point);
+
+/**
+ * @brief Maps a cylinder's local point to UV coordinates.
+ * @param local_point The point in the cylinder's local object space.
+ * @return A T_UV with U = atan2(z,x)/(2π) + 0.5 and V = (y+1)/2.
+ */
+t_uv		cylinder_uv(t_vector local_point);
+
+/**
+ * @brief Maps a cone's local point to UV coordinates.
+ * @param local_point The point in the cone's local object space.
+ * @return A T_UV with U = atan2(z,x)/(2π) + 0.5 and V = y.
+ */
+t_uv		cone_uv(t_vector local_point);
+
+/**
+ * @brief Maps a plane's local point to UV coordinates.
+ * @param local_point The point in the plane's local object space.
+ * @return A T_UV with U = x and V = z.
+ */
+t_uv		plane_uv(t_vector local_point);
+
+/**
+ * @brief Maps a paraboloid's local point to UV coordinates.
+ * @param local_point The point in the paraboloid's local object space.
+ * @return A T_UV with U = atan2(z,x)/(2π) + 0.5 and V = y.
+ */
+t_uv		paraboloid_uv(t_vector local_point);
+
+/**
+ * @brief Maps a hyperboloid's local point to UV coordinates.
+ * @param local_point The point in the hyperboloid's local object space.
+ * @return A T_UV with U = atan2(z,x)/(2π) + 0.5 and V = (y+1)/2.
+ */
+t_uv		hyperboloid_uv(t_vector local_point);
+
+/**
+ * @brief Computes the checkerboard color at a given UV coordinate.
+ * @param uv The UV coordinates on the checkerboard surface.
+ * @return A T_VECTOR of (1,1,1) for white squares or (0,0,0) for black
+ *         squares, based on a checkerboard scale of CHECKER_SCALE.
+ */
+t_vector	get_checker_color(t_uv uv);
 
 #endif

--- a/render_bonus_files/texture_bonus.c
+++ b/render_bonus_files/texture_bonus.c
@@ -1,0 +1,81 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   texture_bonus.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: aramos-r <aramos-r@student.42malaga.com    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/05/04 00:00:00 by aramos-r          #+#    #+#             */
+/*   Updated: 2026/05/04 23:03:04 by aramos-r         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "render_bonus.h"
+
+#define CHECKER_SCALE 4.0
+
+t_uv	sphere_uv(t_vector local_point)
+{
+	t_uv	uv;
+
+	uv.u = atan2(local_point.z, local_point.x) / (2.0 * M_PI) + 0.5;
+	uv.v = asin(local_point.y) / M_PI + 0.5;
+	return (uv);
+}
+
+t_uv	cylinder_uv(t_vector local_point)
+{
+	t_uv	uv;
+
+	uv.u = atan2(local_point.z, local_point.x) / (2.0 * M_PI) + 0.5;
+	uv.v = (local_point.y + 1.0) / 2.0;
+	return (uv);
+}
+
+t_uv	cone_uv(t_vector local_point)
+{
+	t_uv	uv;
+
+	uv.u = atan2(local_point.z, local_point.x) / (2.0 * M_PI) + 0.5;
+	uv.v = local_point.y;
+	return (uv);
+}
+
+t_uv	plane_uv(t_vector local_point)
+{
+	t_uv	uv;
+
+	uv.u = local_point.x;
+	uv.v = local_point.z;
+	return (uv);
+}
+
+t_uv	paraboloid_uv(t_vector local_point)
+{
+	t_uv	uv;
+
+	uv.u = atan2(local_point.z, local_point.x) / (2.0 * M_PI) + 0.5;
+	uv.v = local_point.y;
+	return (uv);
+}
+
+t_uv	hyperboloid_uv(t_vector local_point)
+{
+	t_uv	uv;
+
+	uv.u = atan2(local_point.z, local_point.x) / (2.0 * M_PI) + 0.5;
+	uv.v = (local_point.y + 1.0) / 2.0;
+	return (uv);
+}
+
+t_vector	get_checker_color(t_uv uv)
+{
+	int	iu;
+	int	iv;
+
+	iu = (int)floor(uv.u * CHECKER_SCALE);
+	iv = (int)floor(uv.v * CHECKER_SCALE);
+	if ((iu + iv) % 2 == 0)
+		return (vector_new(1.0, 1.0, 1.0));
+	return (vector_new(0.0, 0.0, 0.0));
+}


### PR DESCRIPTION
Se han creado funciones y estructuras para el checker de los objetos.

Cada objeto tiene su propia funcion que transforma un punto local  a sus coordenadas uv, y ya una funcion generica get_checker_color transforma  ese punto uv en el color que debe tener, blanco o negro. 

La funcion get_color_at_hit nueva ya esta adaptada para implementar este checker teniendo en cuenta la flag nueva en cada obj en su material is_checker.

En el constructor de cada objeto se debera ahora tambien, al mismo estilo de la intersecion, pasar su funcion propia de mapeo de punto local a punto uv.